### PR TITLE
Fix PHP Warning for non defined $tag variable.

### DIFF
--- a/emnm.php
+++ b/emnm.php
@@ -50,6 +50,7 @@ class EasyMultilevelNavMenu {
     function easy_multi_menu_shortcode( $atts = array(), $content = null ){
         // normalize attribute keys, lowercase
         $atts = array_change_key_case( (array) $atts, CASE_LOWER );
+		$tag = '';
         $html = '';
         $html_menu = '';
 
@@ -98,6 +99,7 @@ class EasyMultilevelNavMenu {
     function easy_multi_menu_btn_shortcode( $atts = array(), $content = null ){
         // normalize attribute keys, lowercase
         $atts = array_change_key_case( (array) $atts, CASE_LOWER );
+		$tag = '';
         $html = '';
 
         // override default attributes with user attributes


### PR DESCRIPTION
When using the plugin, error_log file is full of PHP Warnings on each page view like:
PHP Warning:  Undefined variable $tag in (my path)/wp-content/plugins/easy-multilevel-nav-menu/emnm.php on line 65
and
PHP Warning:  Undefined variable $tag in (my path)/wp-content/plugins/easy-multilevel-nav-menu/emnm.php on line 109

My fix is just add an initial definition of that variable:
$tag = '';
in both functions involved
function easy_multi_menu_shortcode() and function easy_multi_menu_btn_shortcode()